### PR TITLE
Use a new name for Amersford / RD new reference system

### DIFF
--- a/src/main/plugin/iso19139.nl.geografie.2.0.0/templates/iso19139.ml.geografie.2.0.0.xml
+++ b/src/main/plugin/iso19139.nl.geografie.2.0.0/templates/iso19139.ml.geografie.2.0.0.xml
@@ -58,7 +58,7 @@
       <gmd:referenceSystemIdentifier>
         <gmd:RS_Identifier>
           <gmd:code>
-            <gmx:Anchor xlink:href="http://www.opengis.net/def/crs/EPSG/0/28992">Amersfoort / RD New</gmx:Anchor>
+            <gmx:Anchor xlink:href="http://www.opengis.net/def/crs/EPSG/0/28992">Rijks Driehoeksstelse</gmx:Anchor>
           </gmd:code>
         </gmd:RS_Identifier>
       </gmd:referenceSystemIdentifier>


### PR DESCRIPTION
* Use `Rijks Driehoeksstelse` instead.