### PR TITLE
Datacite / Rights element custom changes

### DIFF
--- a/src/main/plugin/iso19139.nl.geografie.2.0.0/formatter/datacite/view.xsl
+++ b/src/main/plugin/iso19139.nl.geografie.2.0.0/formatter/datacite/view.xsl
@@ -539,24 +539,6 @@ eg.
       </xsl:for-each>
     </datacite:rightsList>
   </xsl:template>
-  <xsl:template mode="toDatacite"
-                match="gmd:resourceConstraints[1]">
-    <datacite:rightsList>
-      <xsl:for-each select="$metadata//gmd:useLimitation[*/text() != '']">
-        <xsl:apply-templates mode="toDataciteLocalized" select=".">
-          <xsl:with-param name="template">
-            <datacite:rights>
-              <xsl:if test="gmx:Anchor/@xlink:href">
-                <xsl:attribute name="rightsURI"
-                               select="gmx:Anchor/@xlink:href"/>
-              </xsl:if>
-            </datacite:rights>
-          </xsl:with-param>
-        </xsl:apply-templates>
-      </xsl:for-each>
-    </datacite:rightsList>
-  </xsl:template>
-
 
   <!--
   Controlled List Values:

--- a/src/main/plugin/iso19139.nl.geografie.2.0.0/formatter/datacite/view.xsl
+++ b/src/main/plugin/iso19139.nl.geografie.2.0.0/formatter/datacite/view.xsl
@@ -525,6 +525,23 @@ eg.
   <xsl:template mode="toDatacite"
                 match="gmd:resourceConstraints[1]">
     <datacite:rightsList>
+      <xsl:for-each select="$metadata//gmd:resourceConstraints[*/gmd:accessConstraints]/*/gmd:otherConstraints[*/text() != '']">
+        <xsl:apply-templates mode="toDataciteLocalized" select=".">
+          <xsl:with-param name="template">
+            <datacite:rights>
+              <xsl:if test="gmx:Anchor/@xlink:href">
+                <xsl:attribute name="rightsURI"
+                               select="replace(gmx:Anchor/@xlink:href, 'deed.nl', '')"/>
+              </xsl:if>
+            </datacite:rights>
+          </xsl:with-param>
+        </xsl:apply-templates>
+      </xsl:for-each>
+    </datacite:rightsList>
+  </xsl:template>
+  <xsl:template mode="toDatacite"
+                match="gmd:resourceConstraints[1]">
+    <datacite:rightsList>
       <xsl:for-each select="$metadata//gmd:useLimitation[*/text() != '']">
         <xsl:apply-templates mode="toDataciteLocalized" select=".">
           <xsl:with-param name="template">


### PR DESCRIPTION
1) Use the license value defined in resource constraints other constraints element instead of use limitation, that doesn't have a license. 

2) Use the english value for the license link, to avoid issues with Datacite validator

--- 

With a metadata containing the following:

```xml
<gmd:resourceConstraints>
    <gmd:MD_Constraints>
        <gmd:useLimitation>
            <gco:CharacterString>Geen beperkingen</gco:CharacterString>
        </gmd:useLimitation>
    </gmd:MD_Constraints>
</gmd:resourceConstraints>

<gmd:resourceConstraints>
    <gmd:MD_LegalConstraints>
        <gmd:accessConstraints>
            <gmd:MD_RestrictionCode codeListValue="otherRestrictions" codeList="http://schemas.opengis.net/iso/19139/20060504/resources/Codelist/gmxCodelists.xml#MD_RestrictionCode">anders</gmd:MD_RestrictionCode>
        </gmd:accessConstraints>
        <gmd:otherConstraints>
            <gmx:Anchor xlink:href="http://creativecommons.org/publicdomain/mark/1.0/deed.nl">Geen beperkingen</gmx:Anchor>
        </gmd:otherConstraints>
    </gmd:MD_LegalConstraints>
</gmd:resourceConstraints>
```

Before:

```xml
<datacite:rightsList>
  <datacite:rights xml:lang="dut">Geen beperkingen</datacite:rights>
</datacite:rightsList>
```
After:

```xml
<datacite:rightsList>
  <datacite:rights xml:lang="dut" rightsURI="http://creativecommons.org/publicdomain/mark/1.0/">Geen beperkingen</datacite:rights>
</datacite:rightsList>
```