### PR TITLE
Metadata editor / replace the old online resources panel directive with new directives in GeoNetwork 4.4.x

### DIFF
--- a/src/main/plugin/iso19139.nl.geografie.2.0.0/config/associated-panel/default.json
+++ b/src/main/plugin/iso19139.nl.geografie.2.0.0/config/associated-panel/default.json
@@ -38,7 +38,7 @@
         "thumbnailMaker": true
       },
       "icon": "fa gn-icon-thumbnail",
-      "fileStoreFilter": "*.{jpg,JPG,png,PNG,gif,GIF}",
+      "fileStoreFilter": "*.{jpg,JPG,jpeg,JPEG,png,PNG,gif,GIF}",
       "process": "thumbnail-add",
       "fields": {
         "url": {
@@ -54,6 +54,51 @@
     "addInspireDescription": true,
     "wmsResources": {
       "addLayerNamesMode": "resourcename"
+    },
+    "associatedResourcesTypes": [{
+      "type": "parent",
+      "label": "linkToParent",
+      "config": {
+        "sources": {
+          "metadataStore": {
+            "label": "linkToParent",
+            "params": {
+              "resourceType": ["series"],
+              "isTemplate": "n"
+            }
+          },
+          "remoteurl": {"multiple": false}
+        }
+      }
+    }, {
+      "type": "fcats",
+      "label": "linkToFeatureCatalog",
+      "config": {
+        "sources": {
+          "metadataStore": {
+            "label": "linkToFeatureCatalog",
+            "params": {
+              "resourceType": ["featureCatalog"],
+              "isTemplate": "n"
+            }
+          },
+          "remoteurl": {"multiple": false}
+        }
+      }
+    }, {
+      "type": "siblings",
+      "label": "linkToSibling",
+      "config": {
+        "sources": {
+          "metadataStore": {
+            "params": {
+              "isTemplate": "n"
+            }
+          },
+          "remoteurl": {"multiple": true}
+        }
+      }
     }
+    ]
   }
 }

--- a/src/main/plugin/iso19139.nl.geografie.2.0.0/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.nl.geografie.2.0.0/layout/config-editor.xml
@@ -391,13 +391,14 @@
         <directive data-gn-suggestion-list=""/>
 
         <directive data-gn-overview-manager=""
-                   data-file-types=".png,.gif,.jpeg,.jpg"/>
+                   data-file-types=".png,.gif,.jpeg,.jpg"
+                   data-editable-thumbnail="true" />
 
         <directive data-gn-distribution-resources-panel="gnCurrentEdit.metadata"
                    data-mode="viewConfig.distributionConfig.layout || ''"
                    data-editor-config="default"
                    data-related-config="[{
-                                           title: '',
+                                           title: 'Hyperlinks',
                                            filter: 'protocol:.*',
                                            editActions: ['addOnlinesrc']}]"
         />
@@ -869,13 +870,14 @@
         <directive data-gn-suggestion-list=""/>
 
         <directive data-gn-overview-manager=""
-                   data-file-types=".png,.gif,.jpeg,.jpg"/>
+                   data-file-types=".png,.gif,.jpeg,.jpg"
+                   data-editable-thumbnail="true" />
 
         <directive data-gn-distribution-resources-panel="gnCurrentEdit.metadata"
                    data-mode="viewConfig.distributionConfig.layout || ''"
                    data-editor-config="default"
                    data-related-config="[{
-                                           title: '',
+                                           title: 'Hyperlinks',
                                            filter: 'protocol:.*',
                                            editActions: ['addOnlinesrc']}]"
         />
@@ -2082,7 +2084,8 @@
         <directive data-gn-suggestion-list=""/>
 
         <directive data-gn-overview-manager=""
-                   data-file-types=".png,.gif,.jpeg,.jpg"/>
+                   data-file-types=".png,.gif,.jpeg,.jpg"
+                   data-editable-thumbnail="true" />
 
         <directive data-gn-distribution-resources-panel="gnCurrentEdit.metadata"
                    data-mode="viewConfig.distributionConfig.layout || ''"

--- a/src/main/plugin/iso19139.nl.geografie.2.0.0/layout/config-editor.xml
+++ b/src/main/plugin/iso19139.nl.geografie.2.0.0/layout/config-editor.xml
@@ -389,14 +389,26 @@
       <sidePanel>
         <directive data-gn-validation-report=""/>
         <directive data-gn-suggestion-list=""/>
+
+        <directive data-gn-overview-manager=""
+                   data-file-types=".png,.gif,.jpeg,.jpg"/>
+
+        <directive data-gn-distribution-resources-panel="gnCurrentEdit.metadata"
+                   data-mode="viewConfig.distributionConfig.layout || ''"
+                   data-editor-config="default"
+                   data-related-config="[{
+                                           title: '',
+                                           filter: 'protocol:.*',
+                                           editActions: ['addOnlinesrc']}]"
+        />
+
+        <directive data-gn-associated-resources-panel="gnCurrentEdit.metadata" />
       </sidePanel>
 
       <tab id="default" default="true" mode="flat">
 
         <text ref="viewTitle"/>
         <text ref="viewDescription"/>
-
-        <directive data-gn-onlinesrc-list="" types="thumbnail|onlinesrc|parent|fcats|sibling|associated"/>
 
         <section name="dataIdentificatie">
 
@@ -855,14 +867,26 @@
       <sidePanel>
         <directive data-gn-validation-report=""/>
         <directive data-gn-suggestion-list=""/>
+
+        <directive data-gn-overview-manager=""
+                   data-file-types=".png,.gif,.jpeg,.jpg"/>
+
+        <directive data-gn-distribution-resources-panel="gnCurrentEdit.metadata"
+                   data-mode="viewConfig.distributionConfig.layout || ''"
+                   data-editor-config="default"
+                   data-related-config="[{
+                                           title: '',
+                                           filter: 'protocol:.*',
+                                           editActions: ['addOnlinesrc']}]"
+        />
+
+        <directive data-gn-associated-resources-panel="gnCurrentEdit.metadata" />
       </sidePanel>
 
       <tab id="dutch-default" default="true" mode="flat">
 
         <text ref="dutchProfileTitle"/>
         <text ref="dutchProfileDescription"/>
-
-        <directive data-gn-onlinesrc-list="" types="thumbnail|onlinesrc|parent|fcats|sibling|associated"/>
 
         <section name="dataIdentificatie">
 
@@ -2056,61 +2080,75 @@
       <sidePanel>
         <directive data-gn-validation-report=""/>
         <directive data-gn-suggestion-list=""/>
+
+        <directive data-gn-overview-manager=""
+                   data-file-types=".png,.gif,.jpeg,.jpg"/>
+
+        <directive data-gn-distribution-resources-panel="gnCurrentEdit.metadata"
+                   data-mode="viewConfig.distributionConfig.layout || ''"
+                   data-editor-config="default"
+                   data-related-config="[{
+                                           title: '',
+                                           filter: 'protocol:.*',
+                                           editActions: ['addOnlinesrc']}]"
+        />
+
+        <directive data-gn-associated-resources-panel="gnCurrentEdit.metadata" />
       </sidePanel>
 
 
       <tab id="identificationInfo" default="true">
         <text ref="fullViewTitle"/>
         <text ref="fullViewDescription"/>
-        <directive data-gn-onlinesrc-list="" types="thumbnail|onlinesrc|dataset|fcats|sibling|associated"/>
+
         <section xpath="/gmd:MD_Metadata/gmd:identificationInfo" or="identificationInfo"
                  in="/gmd:MD_Metadata"/>
       </tab>
       <tab id="distributionInfo">
         <text ref="fullViewTitle"/>
         <text ref="fullViewDescription"/>
-        <directive data-gn-onlinesrc-list="" types="thumbnail|onlinesrc|dataset"/>
+
         <section xpath="/gmd:MD_Metadata/gmd:distributionInfo" or="distributionInfo"
                  in="/gmd:MD_Metadata"/>
       </tab>
       <tab id="dataQualityInfo">
         <text ref="fullViewTitle"/>
         <text ref="fullViewDescription"/>
-        <directive data-gn-onlinesrc-list="" types="thumbnail|onlinesrc|dataset"/>
+
         <section xpath="/gmd:MD_Metadata/gmd:dataQualityInfo" or="dataQualityInfo"
                  in="/gmd:MD_Metadata"/>
       </tab>
       <tab id="spatialRepresentationInfo">
         <text ref="fullViewTitle"/>
         <text ref="fullViewDescription"/>
-        <directive data-gn-onlinesrc-list="" types="thumbnail|onlinesrc|dataset"/>
+
         <section xpath="/gmd:MD_Metadata/gmd:spatialRepresentationInfo"
                  or="spatialRepresentationInfo" in="/gmd:MD_Metadata"/>
       </tab>
       <tab id="referenceSystemInfo">
         <text ref="fullViewTitle"/>
         <text ref="fullViewDescription"/>
-        <directive data-gn-onlinesrc-list="" types="thumbnail|onlinesrc|dataset"/>
+
         <section xpath="/gmd:MD_Metadata/gmd:referenceSystemInfo" or="referenceSystemInfo"
                  in="/gmd:MD_Metadata"/>
       </tab>
       <tab id="contentInfo" toggle="true">
         <text ref="fullViewTitle"/>
         <text ref="fullViewDescription"/>
-        <directive data-gn-onlinesrc-list="" types="thumbnail|onlinesrc|dataset"/>
+
         <section xpath="/gmd:MD_Metadata/gmd:contentInfo" or="contentInfo" in="/gmd:MD_Metadata"/>
       </tab>
       <tab id="portrayalCatalogueInfo" toggle="true">
         <text ref="fullViewTitle"/>
         <text ref="fullViewDescription"/>
-        <directive data-gn-onlinesrc-list="" types="thumbnail|onlinesrc|dataset"/>
+
         <section xpath="/gmd:MD_Metadata/gmd:portrayalCatalogueInfo" or="portrayalCatalogueInfo"
                  in="/gmd:MD_Metadata"/>
       </tab>
       <tab id="metadata">
         <text ref="fullViewTitle"/>
         <text ref="fullViewDescription"/>
-        <directive data-gn-onlinesrc-list="" types="thumbnail|onlinesrc|dataset"/>
+
         <section name="metadata">
           <field xpath="/gmd:MD_Metadata/gmd:fileIdentifier"/>
           <field xpath="/gmd:MD_Metadata/gmd:language" or="language" in="/gmd:MD_Metadata"/>
@@ -2137,21 +2175,21 @@
       <tab id="metadataConstraints" toggle="true">
         <text ref="fullViewTitle"/>
         <text ref="fullViewDescription"/>
-        <directive data-gn-onlinesrc-list="" types="thumbnail|onlinesrc|dataset"/>
+
         <section xpath="/gmd:MD_Metadata/gmd:metadataConstraints" or="metadataConstraints"
                  in="/gmd:MD_Metadata"/>
       </tab>
       <tab id="metadataMaintenance" toggle="true">
         <text ref="fullViewTitle"/>
         <text ref="fullViewDescription"/>
-        <directive data-gn-onlinesrc-list="" types="thumbnail|onlinesrc|dataset"/>
+
         <section xpath="/gmd:MD_Metadata/gmd:metadataMaintenance" or="metadataMaintenance"
                  in="/gmd:MD_Metadata"/>
       </tab>
       <tab id="applicationSchemaInfo" toggle="true">
         <text ref="fullViewTitle"/>
         <text ref="fullViewDescription"/>
-        <directive data-gn-onlinesrc-list="" types="thumbnail|onlinesrc|dataset"/>
+
         <section xpath="/gmd:MD_Metadata/gmd:applicationSchemaInfo" or="applicationSchemaInfo"
                  in="/gmd:MD_Metadata"/>
       </tab>


### PR DESCRIPTION
The old online resources panel directive is not working fine in 4.4.x, for example fails for parent metadata resources. This pull request uses the new directives added for 4.4.x, that are used already for other metadata schemas like iso19139.

The new panels are displayed in the sidebar so as not to take up too much space in the metadata editor.

Old panel (GeoNetwork 4.2.x):

![old-panel](https://github.com/user-attachments/assets/2bdc03de-bfa9-444c-83c5-6dc5fe09435d)

New panels (GeoNetwork 4.4.x):

![new-panels](https://github.com/user-attachments/assets/37adfb2a-6c8a-40e7-adcd-a7456c8860fe)
