### PR TITLE
Add the application profile with SpatialDataServiceType codelist only for INSPIRE metadata

### DIFF
--- a/src/main/plugin/iso19139.nl.geografie.2.0.0/update-fixed-info.xsl
+++ b/src/main/plugin/iso19139.nl.geografie.2.0.0/update-fixed-info.xsl
@@ -144,30 +144,40 @@
 
       <xsl:apply-templates select="gmd:protocol" />
 
-      <gmd:applicationProfile>
+      <!-- Add applicationProfile if missing for INSPIRE metadata (has the conformance report http://data.europa.eu/eli/reg/2010/1089) -->
+      <xsl:variable name="isInspire" select="boolean(//gmd:report/gmd:DQ_DomainConsistency/gmd:result/gmd:DQ_ConformanceResult/gmd:specification[gmd:CI_Citation/gmd:title/@xlink:href='http://data.europa.eu/eli/reg/2010/1089'])" />
+
       <xsl:choose>
-        <xsl:when test="geonet:contains-any-of($protocol, ('OGC:WMS', 'OGC:WMTS'))">
-              <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view">
-              view</gmx:Anchor>
-        </xsl:when>
-        <xsl:when test="geonet:contains-any-of($protocol, ('OGC:WFS', 'OGC:WCS', 'INSPIRE Atom'))">
-              <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download">
-              download</gmx:Anchor>
-        </xsl:when>
-        <xsl:when test="geonet:contains-any-of($protocol, ('OGC:WCTS'))">
-              <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/transformation">
-              transformation</gmx:Anchor>
-        </xsl:when>
-        <xsl:when test="geonet:contains-any-of($protocol, ('OGC:CSW'))">
-              <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery">
-              discovery</gmx:Anchor>
+        <xsl:when test="$isInspire">
+          <gmd:applicationProfile>
+            <xsl:choose>
+              <xsl:when test="geonet:contains-any-of($protocol, ('OGC:WMS', 'OGC:WMTS'))">
+                <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view">
+                  view</gmx:Anchor>
+              </xsl:when>
+              <xsl:when test="geonet:contains-any-of($protocol, ('OGC:WFS', 'OGC:WCS', 'INSPIRE Atom'))">
+                <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download">
+                  download</gmx:Anchor>
+              </xsl:when>
+              <xsl:when test="geonet:contains-any-of($protocol, ('OGC:WCTS'))">
+                <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/transformation">
+                  transformation</gmx:Anchor>
+              </xsl:when>
+              <xsl:when test="geonet:contains-any-of($protocol, ('OGC:CSW'))">
+                <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery">
+                  discovery</gmx:Anchor>
+              </xsl:when>
+              <xsl:otherwise>
+                <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/other">
+                  other</gmx:Anchor>
+              </xsl:otherwise>
+            </xsl:choose>
+          </gmd:applicationProfile>
         </xsl:when>
         <xsl:otherwise>
-              <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/other">
-              other</gmx:Anchor>
+          <xsl:apply-templates select="gmd:applicationProfile" />
         </xsl:otherwise>
       </xsl:choose>
-      </gmd:applicationProfile>
 
       <xsl:apply-templates select="gmd:name" />
 


### PR DESCRIPTION
Previously, it was added based on the protocol for any metadata. In the previous version 1.3.1, the approach was different: the SpatialDataServiceType reference was assigned only when the user-entered value contained “discovery,” “view,” “download,” “transformation,” “invoke,” or “other”; otherwise, the value was retained.

**With this change, the application profile is added only if the metadata has a http://data.europa.eu/eli/reg/2010/1089 compliance report; otherwise, the value entered by the user is retained.**

This is not entirely accurate according to the specification, as it depends on the remote server’s endpoint compliance with INSPIRE, not on the metadata itself. However, it is an improvement over the current behavior, which adds the element to any metadata, even if it is not related to INSPIRE.

From the specification:

> The example below sets out the method for the simpler data service link for INSPIRE. The optional applicationProfile element has been added. It indicates that it is an INSPIRE view service. Only for the services that provide the INSPIRE view or the INSPIRE download service this element is included. For example, if an ATOM and a WFS are available and only the ATOM complies with the INSPIRE specifications of download, this element with the value download service will only be added to the ATOM